### PR TITLE
Test the bug 669 fix

### DIFF
--- a/TestMethod.sc
+++ b/TestMethod.sc
@@ -25,4 +25,43 @@ TestMethod : UnitTest {
 		);
 	}
 
+	test_classnameAsMethodCrash {
+	    try
+	    {	    
+	        1 fooBar: 2;
+	    }
+	    {	
+		|error|
+		    "1 fooBar: 2 threw an exception (no method)".postln;
+		error.errorString.postln;
+	    };
+
+	    try
+	    {	    
+	        1 FooBar: 2;
+	    }
+	    {	
+		|error|
+		"1 FooBar: 2 threw an exception (FooBar is not a method)".postln;
+		error.errorString.postln;
+	    };
+
+	    if( Main.versionAtLeast( 3, 8 ),
+		{
+		    try
+		    {	    
+			1 Object: 2;
+		    }
+		    {	
+			|error|
+			    "1 Object: 2 threw an exception (Object is a class not a method)".postln;
+			error.errorString.postln;
+		    };
+		},
+		{
+		    "Don't test '1 Object: 2' until rev 3.8 at least (Issue #669)".postln;
+		}
+	    );
+	}
+
 } // End class


### PR DESCRIPTION
Now that https://github.com/supercollider/supercollider/pull/2166 is merged, we could add this test that demonstrates it no longer segfaults.

Note the test conditions on 3.8 version, which I think is right. If you'd like a different condition there that's fine. This test passed for be both in 3.7.1 and with my dev version with the above pull request built in. 

Thanks!
