### PR TITLE
Add mocked server methods to TestEvent

### DIFF
--- a/TestEvent.sc
+++ b/TestEvent.sc
@@ -104,6 +104,7 @@ TestEvent : UnitTest {
 
 	nextNodeID { ^-1 }
 	latency { ^0.2 }
-	
+	defaultGroupID { ^1 }
+	defaultGroup { ^Group.basicNew(nil, 1) }
 }
 


### PR DESCRIPTION
This commit adds mocks for defaultGroupID and defaultGroup to TestEvent, which are necessary to get https://github.com/supercollider/supercollider/pull/3180 to work. We shouldn't really be editing this old deprecated repository, but unfortunately our CI system currently uses it, so this modification serves as a quick fix.