### PR TITLE
Update TestDate.sc

### DIFF
--- a/TestDate.sc
+++ b/TestDate.sc
@@ -15,8 +15,6 @@ TestDate : UnitTest {
 			"rawSeconds is used if specified");
 
 		d = Date(2017, 10, 25);
-		this.assertEquals(d.rawSeconds, 1508882400,
-			"Computed rawSeconds");
 		this.assertEquals(d.dayOfWeek, 3,
 			"Computed dayOfWeek");
 
@@ -48,7 +46,8 @@ TestDate : UnitTest {
 			"new with defaults");
 		this.assertEquals(Date(2016).stamp, "160101_000000",
 			"new with defaults");
-		this.assertEquals(Date(2010, day: 15, minute: 30).rawSeconds, 1263511800,
+		this.assertEquals(Date(2010, day: 15, minute: 30).asSortableString,
+			"20100115003000",
 			"new with defaults");
 
 		e = nil;
@@ -58,9 +57,9 @@ TestDate : UnitTest {
 
 		d = Date(2017, 10, 25);
 		this.assertEquals(
-			[d.asSortableString, d.dayOfWeek, d.rawSeconds],
-			[ "20171025000000", 3, 1508882400],
-			"dayOfWeek and rawSeconds are computed");
+			[d.asSortableString, d.dayOfWeek],
+			[ "20171025000000", 3],
+			"dayOfWeek is computed");
 
 		this.assertEquals(Date(2017, 10, 31, dayOfWeek: 0).dayOfWeek, 2,
 			"dayOfWeek always computed");
@@ -71,23 +70,23 @@ TestDate : UnitTest {
 			"invalid dates are corrected (not leap year)");
 
 		this.assertEquals(
-			Date.newFromFormattedString("2017-10-25 13:25:55", "%Y-%m-%d %H:%M:%S"),
+			Date.fromString("2017-10-25 13:25:55", "%Y-%m-%d %H:%M:%S"),
 			Date(2017, 10, 25, 13, 25, 55),
-			"newFromFormattedString");
+			"fromString");
 		this.assertEquals(
-			Date.newFromFormattedString("2017-10-25 [13:25:55]", "%Y-%m-%d [%H:%M:%S]"),
+			Date.fromString("2017-10-25 [13:25:55]", "%Y-%m-%d [%H:%M:%S]"),
 			Date(2017, 10, 25, 13, 25, 55),
-			"newFromFormattedString");
+			"fromString");
 		this.assertEquals(
-			Date.newFromFormattedString("1981.9.30 @ 17:33", "%Y.%m.%d @ %H:%M"),
+			Date.fromString("1981.9.30 @ 17:33", "%Y.%m.%d @ %H:%M"),
 			Date(1981, 9, 30, 17, 33),
-			"newFromFormattedString");
+			"fromString");
 
 		// Round-trip via string, using "stamp"
 		{
 			var orig = Date(2013, 5, 25, 10, 9, 8);
 			var stampString = orig.stamp;
-			var d = Date.newFromFormattedString(stampString, "%y%m%d_%H%M%S");
+			var d = Date.fromString(stampString, "%y%m%d_%H%M%S");
 			this.assertEquals(d, orig,
 				"round trip via string using 'stamp'");
 		}.value;
@@ -129,7 +128,7 @@ TestDate : UnitTest {
 		// Try a roundtrip to/from string, using "stamp"
 		{
 			var d = Date(2013, 12, 11, 10, 9, 8);
-			var d2 = Date.newFromFormattedString(d.stamp, "%y%m%d_%H%M%S").postln;
+			var d2 = Date.fromString(d.stamp, "%y%m%d_%H%M%S").postln;
 			this.assertEquals(d, d2,
 				"roundtrip to/from string using stamp");
 		}.value;


### PR DESCRIPTION
- rename Date.newFromFormattedString to Date.fromString
- fix testing issue with rawSeconds being different on platforms with different time zones (don't assume specific rawSeconds values in tests!).